### PR TITLE
changed Csdr version to working 0.18 (May 2023), lib copied to /usr/lib

### DIFF
--- a/src/build_csdr
+++ b/src/build_csdr
@@ -21,6 +21,7 @@ if [ -d ${GITPROJ} ]; then
 else
   git clone https://github.com/${GITUSER}/${GITPROJ}.git
 fi
+git checkout fcb7010f10b # install 0.18
 
 cd ${BASE}/git/${GITUSER}/build_${GITPROJ}
 cmake ../${GITPROJ} -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$HOME/.local

--- a/src/inst_csdr
+++ b/src/inst_csdr
@@ -8,7 +8,7 @@ GITPROJ=csdr
 
 cd ${BASE}/git/${GITUSER}/build_${GITPROJ}
 sudo -u ${FMLIST_SCAN_USER} make install
-
+cp /home/${FMLIST_SCAN_USER}/.local/lib/libcsdr.so.0.18.0 /usr/lib # (hardcoded) filename to be copied into /usr/lib
 ldconfig
 
 cd ${BASE}


### PR DESCRIPTION
Siehe https://www.fmlist.org/urds/urdslister_fm_rds.php?id=13782

Hier wurde kein UKW geloggt.

Dank der eingebauten Check-Routinen konnte ich dann das Problem einkreisen.

Drauf gekommen bin ich beim letzten von 4 Checks von `scanTest.sh 100100`, das bei meinem lokalen Sender auf 100,1 MHz zwar RDS mit rtl_fm dekodieren konnte (check 2/4), aber nicht mit dem ganzen Block (check 4/4), denn es gab dort eine Fehlermeldung von *csdr*, die mich auf die Idee brachte, dort mal nachzuschauen.

Der Fehler war also doch NICHT bei rdsspy, sondern bei csdr, das in der neuesten Version NICHT mit dem Scanner kompatibel ist. Vermutlich ist da ein Parameter anders oder kann nicht mehr richtig verarbeitet werden.

Hab dann auf meinem Scanner geschaut, welche Version (commit) installiert ist und dann mit

```
git checkout fcb7010f10b
```

auf den damaligen Stand vom Mai 2023 zurückversetzt. Den Befehl hab ich dann noch in `src/build_csdr` unter dem git clone Befehl (und außerhalb des if) platziert.

Zusätzlich hab ich die `libcsdr.so.0.18` nach `/usr/lib` kopiert